### PR TITLE
Bruker absolute-url i treff

### DIFF
--- a/src/main/resources/lib/search/resultListing/getPaths.es6
+++ b/src/main/resources/lib/search/resultListing/getPaths.es6
@@ -30,6 +30,7 @@ export default function getPaths(el) {
         // href for everything else
         paths.href = pageUrl({
             id: el._id,
+            type: 'absolute'
         });
     }
 


### PR DESCRIPTION
Sørger for at søket i dekoratøren får korrekte hrefs ved bruk på andre subdomener enn www*.