### PR TITLE
Endrer dato-sortering

### DIFF
--- a/src/main/resources/lib/nav-utils/index.es6
+++ b/src/main/resources/lib/nav-utils/index.es6
@@ -1,20 +1,3 @@
-const libs = {
-    i18n: require('/lib/xp/i18n'),
-    moment: require('/assets/momentjs/2.24.0/min/moment-with-locales.min.js'),
-    repo: require('/lib/xp/repo'),
-    node: require('/lib/xp/node'),
-    context: require('/lib/xp/context'),
-};
-
-/**
- * @description Date formats on content created in XP7 is not necessarily supported in the Date wrapper in XP7 (but it does work in browsers)
- * @param {string} date Date
- * @returns {string} Correctly formated date
- */
-const fixDateFormat = (date) => {
-    return date.indexOf('.') !== -1 ? date.split('.')[0] + 'Z' : date;
-};
-
 /**
  * Make sure the content is an array.
  * @param {*} content Whatever is passed in
@@ -27,42 +10,6 @@ const forceArray = (content) => {
     return [];
 };
 
-const formatDate = (date, language) => {
-    // use nb(DD.MM.YYYY) for everything except for english content(MM/DD/YYYY)
-    return libs
-        .moment(date)
-        .locale(language === 'en' ? 'en' : 'nb')
-        .format('L');
-};
-
-const dateTimePublished = (content, language) => {
-    if (!content) {
-        return '';
-    }
-    const navPublished = libs.i18n.localize({
-        key: 'main_article.published',
-        locale: language,
-    });
-    const p = fixDateFormat(content.publish.from ? content.publish.from : content.createdTime);
-    const published = formatDate(p, language);
-    const publishedString = `${navPublished} ${published}`;
-
-    let modifiedString = '';
-    const m = fixDateFormat(content.modifiedTime);
-    if (new Date(m) > new Date(p)) {
-        const navUpdated = libs.i18n.localize({
-            key: 'main_article.lastChanged',
-            locale: language,
-        });
-        const lastModified = formatDate(content.modifiedTime, language);
-        modifiedString = ` | ${navUpdated} ${lastModified}`;
-    }
-    return publishedString + modifiedString;
-};
-
 module.exports = {
-    fixDateFormat,
-    formatDate,
     forceArray,
-    dateTimePublished,
 };

--- a/src/main/resources/lib/search/helpers/dateRange.es6
+++ b/src/main/resources/lib/search/helpers/dateRange.es6
@@ -9,17 +9,17 @@ const getDateRangeQueryStringFromBucket = (bucket) => {
     let s = '';
     if (to) {
         s +=
-            ' AND (publish.from <= dateTime("' +
+            ' AND (publish.first <= dateTime("' +
             to +
-            '") OR publish.from NOT LIKE "*") AND (modifiedTime <= dateTime("' +
+            '") OR publish.first NOT LIKE "*") AND (createdTime <= dateTime("' +
             to +
-            '") OR modifiedTime NOT LIKE "*")';
+            '") OR createdTime NOT LIKE "*")';
     }
     if (from) {
         s +=
-            ' AND (publish.from > dateTime("' +
+            ' AND (publish.first > dateTime("' +
             from +
-            '") OR modifiedTime > dateTime("' +
+            '") OR createdTime > dateTime("' +
             from +
             '"))';
     }

--- a/src/main/resources/lib/search/helpers/utils.es6
+++ b/src/main/resources/lib/search/helpers/utils.es6
@@ -63,7 +63,7 @@ export function getFacetConfiguration() {
 
 export function getSortedResult(ESQuery, sort) {
     if (sort && sort !== '0') {
-        return query({ ...ESQuery, sort: 'publish.from DESC, createdTime DESC' });
+        return query({ ...ESQuery, sort: 'publish.first DESC, createdTime DESC' });
     }
 
     return query({ ...ESQuery, sort: '_score DESC' });

--- a/src/main/resources/lib/search/resultListing/createPreparedHit.es6
+++ b/src/main/resources/lib/search/resultListing/createPreparedHit.es6
@@ -1,28 +1,5 @@
-import navUtils from '/lib/nav-utils';
 import getRepository from '../helpers/repo';
 import getPaths from './getPaths';
-
-/*
-  -------- Coarse algorithm for setting class name to an result element -------
-  1. Assume the classname is information, many prioritised elements dont have class names
-  2. If it is a file, set it to be pdf
-  TODO check what media file it is and set class name accordingly
-  3. If it has been mapped with facets, set the classname attribute as its classname
-*/
-const getClassName = (el) => {
-    let className = 'informasjon';
-    if (el.type.startsWith('media')) {
-        className = 'pdf';
-    }
-    if (el.x && el.x['no-nav-navno'] && el.x['no-nav-navno'].fasetter && !el.priority) {
-        if (el.x['no-nav-navno'].fasetter.className) {
-            className = el.x['no-nav-navno'].fasetter.className;
-        } else if (el.x['no-nav-navno'].fasetter.fasett === 'Statistikk') {
-            className = 'statistikk';
-        }
-    }
-    return className;
-};
 
 export function calculateHighlightText(highLight) {
     if (highLight.ingress.highlighted) {
@@ -168,7 +145,6 @@ export default function createPreparedHit(hit, wordList) {
     const paths = getPaths(hit);
     const href = paths.href;
     const displayPath = paths.displayPath;
-    const className = getClassName(hit);
     let name = hit.displayName;
 
     let officeInformation;
@@ -204,11 +180,6 @@ export default function createPreparedHit(hit, wordList) {
         };
     }
 
-    let publishedString = null;
-    if (hit.type !== 'no.nav.navno:office-information') {
-        publishedString = navUtils.dateTimePublished(hit, hit.language || 'no');
-    }
-
     return {
         priority: !!hit.priority,
         displayName: name,
@@ -218,8 +189,6 @@ export default function createPreparedHit(hit, wordList) {
         publish: hit.publish,
         createdTime: hit.createdTime,
         modifiedTime: hit.modifiedTime,
-        className: className,
         officeInformation: officeInformation,
-        publishedString: publishedString,
     };
 }

--- a/src/main/resources/services/search/search.es6
+++ b/src/main/resources/services/search/search.es6
@@ -3,11 +3,9 @@ const searchUtils = require('/lib/search');
 const bucket = (type, params, parent) => {
     return (element, index) => {
         const el = element;
-        el.className = '';
         if (type === 'fasett') {
             el.checked = Number(params.f || 0) === index;
             el.default = el.checked && (!params.uf || Number(params.uf) === -1);
-            el.defaultClassName = el.default ? 'erValgt' : '';
             el.underaggregeringer.buckets = el.underaggregeringer.buckets.map(
                 bucket('under', params, el)
             );
@@ -15,13 +13,7 @@ const bucket = (type, params, parent) => {
             el.checked =
                 parent.checked &&
                 (Array.isArray(params.uf) ? params.uf : [params.uf]).indexOf(String(index)) > -1;
-            const cname =
-                parent.key === 'Innhold'
-                    ? el.key.split(' ')[0].toLowerCase() + ' '
-                    : parent.key.split(' ')[0].toLowerCase() + ' ';
-            el.className += cname;
         }
-        el.className += el.checked ? 'erValgt' : '';
         return el;
     };
 };

--- a/src/main/resources/site/content-types/search-api2/search-api2.xml
+++ b/src/main/resources/site/content-types/search-api2/search-api2.xml
@@ -23,19 +23,5 @@
             <label>Ingress</label>
             <occurrences minimum="1" maximum="1"/>
         </input>
-        <input name="className" type="RadioButton">
-            <label>Søkeikon</label>
-            <config>
-                <option value="lokalt">Lokalt</option>
-                <option value="tjenester">Tjenester</option>
-                <option value="nyheter">Nyheter</option>
-                <option value="statistikk">Statistikk</option>
-                <option value="pdf">PDF</option>
-                <option value="excel">Excel</option>
-                <option value="informasjon">Informasjon</option>
-                <option value="kontor">Kontor</option>
-                <option value="skjema">Skjema</option>
-            </config>
-        </input>
     </form>
 </content-type>

--- a/src/main/resources/site/content-types/search-config2/search-config2.xml
+++ b/src/main/resources/site/content-types/search-config2/search-config2.xml
@@ -26,20 +26,6 @@
                         <input name="rulevalue" type="TextLine">
                             <label>Regelverdi</label>
                         </input>
-                        <input name="className" type="RadioButton">
-                            <label>Fasettikon</label>
-                            <config>
-                                <option value="lokalt">Lokalt</option>
-                                <option value="tjenester">Tjenester</option>
-                                <option value="nyheter">Nyheter</option>
-                                <option value="statistikk">Statistikk</option>
-                                <option value="pdf">PDF</option>
-                                <option value="excel">Excel</option>
-                                <option value="informasjon">Informasjon</option>
-                                <option value="kontor">Kontor</option>
-                                <option value="skjema">Skjema</option>
-                            </config>
-                        </input>
                     </items>
                     <occurrences minimum="0" maximum="0"/>
                 </item-set>

--- a/src/main/resources/site/content-types/search-priority/search-priority.xml
+++ b/src/main/resources/site/content-types/search-priority/search-priority.xml
@@ -10,19 +10,5 @@
             <label>Nøkkelord</label>
             <occurrences minimum="0" maximum="0"/>
         </input>
-        <input name="className" type="RadioButton">
-            <label>Søkeikon</label>
-            <config>
-                <option value="lokalt">Lokalt</option>
-                <option value="tjenester">Tjenester</option>
-                <option value="nyheter">Nyheter</option>
-                <option value="statistikk">Statistikk</option>
-                <option value="pdf">PDF</option>
-                <option value="excel">Excel</option>
-                <option value="informasjon">Informasjon</option>
-                <option value="kontor">Kontor</option>
-                <option value="skjema">Skjema</option>
-            </config>
-        </input>
     </form>
 </content-type>


### PR DESCRIPTION
- Bruker publish.first og createdTime for dato-sortering (tidligere publish.from og modifiedTime). Dette matcher sorteringen som vises i XP-frontend.
- Sender med createdTime i response for søkeresultat, slik at denne er tilgjengelig for søk-frontend.
- Fjerner ubrukte felt i response, og relatert funksjonalitet ('className' og 'publishedString')