### PR TITLE
Legger til sjekk av innholdstype for å angi visning av datomerkinger

### DIFF
--- a/src/main/resources/lib/search/result/createPreparedHit.es6
+++ b/src/main/resources/lib/search/result/createPreparedHit.es6
@@ -27,7 +27,6 @@ export const shouldHidePublishDate = (hit) => {
         `${CONTENT_TYPE_PREFIX}:themed-article-page`,
         `${CONTENT_TYPE_PREFIX}:content-page-with-sidemenus`,
         `${CONTENT_TYPE_PREFIX}:tools-page`,
-        `${CONTENT_TYPE_PREFIX}:current-topic-page`,
     ].includes(hit.type);
 };
 

--- a/src/main/resources/lib/search/result/createPreparedHit.es6
+++ b/src/main/resources/lib/search/result/createPreparedHit.es6
@@ -1,5 +1,7 @@
 import { getContentRepoConnection } from '../../utils/repo';
 
+const CONTENT_TYPE_PREFIX = 'no.nav.navno';
+
 export const calculateHighlightText = (highLight) => {
     if (highLight.ingress.highlighted) {
         return highLight.ingress.text;
@@ -14,6 +16,19 @@ export const calculateHighlightText = (highLight) => {
         return highLight.text.text;
     }
     return '';
+};
+
+export const shouldHidePublishDate = (hit) => {
+    return [
+        `${CONTENT_TYPE_PREFIX}:situation-page`,
+        `${CONTENT_TYPE_PREFIX}:office-branch`,
+        `${CONTENT_TYPE_PREFIX}:guide-page`,
+        `${CONTENT_TYPE_PREFIX}:generic-page`,
+        `${CONTENT_TYPE_PREFIX}:themed-article-page`,
+        `${CONTENT_TYPE_PREFIX}:content-page-with-sidemenus`,
+        `${CONTENT_TYPE_PREFIX}:tools-page`,
+        `${CONTENT_TYPE_PREFIX}:current-topic-page`,
+    ].includes(hit.type);
 };
 
 /*
@@ -232,5 +247,6 @@ export const createPreparedHit = (hit, wordList) => {
         officeInformation: getOfficeInformation(hit),
         audience: getAudienceForHit(hit),
         language: hit.language,
+        hidePublishDate: shouldHidePublishDate(hit),
     };
 };

--- a/src/main/resources/lib/search/result/createPreparedHit.es6
+++ b/src/main/resources/lib/search/result/createPreparedHit.es6
@@ -18,6 +18,13 @@ export const calculateHighlightText = (highLight) => {
     return '';
 };
 
+export const shouldHideModifiedDate = (hit) => {
+    return [
+        `${CONTENT_TYPE_PREFIX}:overview`,
+        `${CONTENT_TYPE_PREFIX}:forms-overview`,
+    ].includes(hit.type);
+};
+
 export const shouldHidePublishDate = (hit) => {
     return [
         `${CONTENT_TYPE_PREFIX}:situation-page`,
@@ -27,6 +34,8 @@ export const shouldHidePublishDate = (hit) => {
         `${CONTENT_TYPE_PREFIX}:themed-article-page`,
         `${CONTENT_TYPE_PREFIX}:content-page-with-sidemenus`,
         `${CONTENT_TYPE_PREFIX}:tools-page`,
+        `${CONTENT_TYPE_PREFIX}:overview`,
+        `${CONTENT_TYPE_PREFIX}:forms-overview`,
     ].includes(hit.type);
 };
 
@@ -247,5 +256,6 @@ export const createPreparedHit = (hit, wordList) => {
         audience: getAudienceForHit(hit),
         language: hit.language,
         hidePublishDate: shouldHidePublishDate(hit),
+        hideModifiedDate: shouldHideModifiedDate(hit),
     };
 };

--- a/src/main/resources/lib/search/searchWithoutAggregations.es6
+++ b/src/main/resources/lib/search/searchWithoutAggregations.es6
@@ -2,6 +2,7 @@ import {
     calculateHighlightText,
     getAudienceForHit,
     getHighLight,
+    shouldHidePublishDate,
 } from './result/createPreparedHit';
 import { runSearchQuery } from './query/runSearchQuery';
 import { logger } from '../utils/logger';
@@ -33,6 +34,7 @@ const runSearch = (params) => {
             rawScore: hit._rawScore,
             audience: getAudienceForHit(hit),
             language: hit.language,
+            hidePublishDate: shouldHidePublishDate(hit),
         };
     });
 

--- a/src/main/resources/lib/search/searchWithoutAggregations.es6
+++ b/src/main/resources/lib/search/searchWithoutAggregations.es6
@@ -3,6 +3,7 @@ import {
     getAudienceForHit,
     getHighLight,
     shouldHidePublishDate,
+    shouldHideModifiedDate,
 } from './result/createPreparedHit';
 import { runSearchQuery } from './query/runSearchQuery';
 import { logger } from '../utils/logger';
@@ -35,6 +36,7 @@ const runSearch = (params) => {
             audience: getAudienceForHit(hit),
             language: hit.language,
             hidePublishDate: shouldHidePublishDate(hit),
+            hideModifiedDate: shouldHideModifiedDate(hit),
         };
     });
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Setter flagg hidePublishDate og/eller hideModifiedDate avhengig av hvilken innholdstype siden er.
Dynamiske sider skal kun ha oppdatert dato, mens oversiktssider skal ikke ha datoer i det heletatt. Alle andre (gamle sider) skal ha både publisert og oppdatert dato.

## Testing
Testes i dev.