### PR TITLE
Forbedrer skjemanummer-søk

### DIFF
--- a/src/main/resources/lib/search/query/generateSearchInput.es6
+++ b/src/main/resources/lib/search/query/generateSearchInput.es6
@@ -4,9 +4,14 @@ import { getSynonymMap } from '../helpers/cache';
 const fuzzynessPerChar = 1 / 4;
 const maxFuzzyness = 3;
 
-// Matches form numbers
-const isFormSearch = (ord) => {
-    return /^\d\d-\d\d\.\d\d$/.test(ord);
+// Matches on form number-like queries and returns the full valid form number if match found
+const getCompleteFormNumberIfFormSearch = (ord) => {
+    const match = /^(nav.?)?([0-9]{2}).?([0-9]{2}).?([0-9]{2})$/.exec(ord);
+    if (!match) {
+        return null;
+    }
+
+    return `nav ${match[2]}-${match[3]}.${match[4]}`;
 };
 
 const isExactSearch = (queryString) =>
@@ -109,8 +114,9 @@ export const generateSearchInput = (userInput) => {
         return { wordList: [], queryString: '' };
     }
 
-    if (isFormSearch(userInput)) {
-        return { wordList: [userInput], queryString: userInput };
+    const formNumber = getCompleteFormNumberIfFormSearch(userInput);
+    if (formNumber) {
+        return { wordList: [formNumber], queryString: formNumber };
     }
 
     const sanitizedTerm = sanitize(userInput);

--- a/src/main/resources/lib/search/query/generateSearchInput.es6
+++ b/src/main/resources/lib/search/query/generateSearchInput.es6
@@ -11,7 +11,7 @@ const getCompleteFormNumberIfFormSearch = (ord) => {
         return null;
     }
 
-    return `nav ${match[2]}-${match[3]}.${match[4]}`;
+    return `"nav ${match[2]}-${match[3]}.${match[4]}"`;
 };
 
 const isExactSearch = (queryString) =>

--- a/src/main/resources/lib/utils/validateInput.es6
+++ b/src/main/resources/lib/utils/validateInput.es6
@@ -38,7 +38,7 @@ export const validateAndTransformParams = (params) => {
     const config = getConfig();
 
     // Support max 200 characters for the search term
-    const ordTrimmed = ord.substring(0, 200).trim();
+    const ordTrimmed = ord.substring(0, 200).trim().toLowerCase();
 
     const startValid = validNumber(start, 0);
     const countMin = startValid + 1; // end batch must be at least one step above the start batch


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Gjør søk på faktisk skjemanummer på alle søk som består av tre grupper med 2 tall, med optional separator-tegn og "nav"-prefix
Eksempler som skal gi treff på skjemanummer:
- nav 01-02-03
- nav010203
- 01-02-03
- 010203